### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Nginx Configs
+# Nginx Configs
 
 Collection of Nginx configs for most popular CMS/CMF/Frameworks based on PHP.
 
-##Table of Contents
+## Table of Contents
 
 - [Asgard CMS](configs/asgard-cms.conf)
 - [Bolt CMS](configs/bolt-cms.conf)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
