### PR TITLE
fix: invalid clean url mode 2 in data-life-engine.conf

### DIFF
--- a/configs/data-life-engine.conf
+++ b/configs/data-life-engine.conf
@@ -11,7 +11,7 @@ location / {
   rewrite ^/([^.]+)/page,([0-9]+),([0-9]+),([0-9]+)-(.*).html(/?)$ /index.php?newsid=$4&news_page=$2&cstart=$3;
   rewrite ^/([^.]+)/page,([0-9]+),([0-9]+)-(.*).html(/?)$ /index.php?newsid=$3&news_page=$2;
   rewrite ^/([^.]+)/print:page,([0-9]+),([0-9]+)-(.*).html(/?)$ /engine/print.php?news_page=$2&newsid=$3;
-  rewrite ^/([^.]+)/([0-9]+)-(.*).html(/?)$ /index.php?newsid=$2;
+  rewrite ^/([^.]+)/([0-9]+)-(.*).html(/?)$ /index.php?seocat=$1&newsid=$2&seourl=$3;
 
   rewrite ^/page,([0-9]+),([0-9]+),([0-9]+)-(.*).html(/?)+$ /index.php?newsid=$3&news_page=$1&cstart=$2;
   rewrite ^/page,([0-9]+),([0-9]+)-(.*).html(/?)+$ /index.php?newsid=$2&news_page=$1;


### PR DESCRIPTION
`seourl` and `seocat` GET parameters should be specified, matched by regex groups 1 and 3 accordingly. This is required to prevent infinite redirects and in order for invalid URLs to be redirected to a valid ones. 


`engine/modules/show.full.php:355`

```php
if ($_GET['seourl'] != $row['alt_name'] OR $_GET['seocat'] != $c_url OR strpos ( $_SERVER['REQUEST_URI'], "?" )
```